### PR TITLE
getting default document page from configuration

### DIFF
--- a/TWDocs.inc
+++ b/TWDocs.inc
@@ -113,7 +113,6 @@ abstract class TWDocs {
    */
   public function render( $pageid, $content )
   {
-	file_put_contents("/tmp/docsRender", "$content") ;
     TWDocs::getLogger()->logStatus( "*****STARTING A NEW QUERY*****." ) ;
 
     $this->pageid = $pageid ;
@@ -251,7 +250,8 @@ abstract class TWDocs {
           $fulldir = "/var/www/html/tw.rpi.edu/media/files" ;
           $fullpath = $fulldir."/latest/".$oldName ;
           $actualuri = $base."latest/".$oldName ;
-          $page = "http://tw.rpi.edu/web/doc/Document?uri=$actualuri" ;
+          $defaultdocpage = $this->getDefaultDocPage() ;
+          $page = $defaultdocpage."?uri=$actualuri" ;
         }
       }
     }
@@ -305,7 +305,6 @@ abstract class TWDocs {
 
   private function doesFileExist($href) {
     $result = $this->makeApiCall("checkInUse",array("file"=>$href));
-    file_put_contents("/tmp/fileexists", $result);
     if($result===null || $result->response==FALSE) return FALSE;
     return TRUE;
   }
@@ -328,7 +327,6 @@ abstract class TWDocs {
     foreach($args as $param => $value) {
       $msg .= "&$param=".urlencode($value);
     }
-	file_put_contents("/tmp/apiCall", "$msg - " . $this->getApiURL()) ;
     $params = array('http' => array('method' => 'POST',
             'content' => $msg));
     $ctx = stream_context_create($params);
@@ -355,6 +353,8 @@ abstract class TWDocs {
   public abstract function setServiceID($val);
   public abstract function getApiKey();
   public abstract function setApiKey($val);
+  public abstract function getDefaultDocPage();
+  public abstract function setDefaultDocPage($val);
 
   function getApiURL() {
     return $this->getBaseURI()."api.php";


### PR DESCRIPTION
<!--
Thank you for your contribution! Here’s a template to help you format your PR.
 
Your title should look like: UXTALK-NUM Clear, brief title using imperative tense
For example: UXTALK-104 Refactor web consumer to handle API prefix removal
-->
 
### What does this PR do?
Retrieves the default document page from configuration instead of hardcoded 
 
### Motivation and context
https://github.com/tetherless-world/twdocs-drupal8/issues/3
 
### Screenshots or videos, if appropriate
![screen shot 2018-05-03 at 8 35 13 pm](https://user-images.githubusercontent.com/1447926/39611110-4394c1d4-4f12-11e8-9b27-d2d7eef66545.png)
 
 
### How has this been tested?
 
<!-- Please describe in detail how you tested your changes beyond automated tests. -->
 
### Checklist
 
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “[n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
 
* [x] Renders and functions properly in all supported browsers
* [x] Automated tests written and passing (n/a)
* [x] Documentation created or updated, including (n/a)
* [x] There is a single commit with a [Good commit message](https://github.com/torvalds/subsurface-for-dirk/blob/master/README#L92) that starts with the Jira ticket
 
<!-- If any of the above need further details, you should include those here. -->
 
### How does this PR make you feel?
 
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
 
![On fire](https://media.giphy.com/media/tjLaaAfBm3LR6/giphy.gif)
