### PR TITLE
twdocs-0006 differentiate media uri from instance uri in configuration

### DIFF
--- a/TWDocs.inc
+++ b/TWDocs.inc
@@ -237,8 +237,8 @@ abstract class TWDocs {
       $params["mode"] = "link";
     } else {
       $class = "";
-      $base = $this->getBaseURI() ;
-      $uri = $base.$params["version"]."/".$params["href"];
+      $baseMedia = $this->getMediaURI() ;
+      $uri = $baseMedia."/".$params["version"]."/".$params["href"];
       $page = $this->getProperty($uri,"http://xmlns.com/foaf/0.1/page");
       if($page != null && count($page)>0) {
         $page = $page[0];
@@ -247,9 +247,8 @@ abstract class TWDocs {
         $arr = explode( "/", $uri ) ;
         if( count( $arr ) > 0 ) { 
           $oldName = $arr[count( $arr ) - 1] ;
-          $fulldir = "/var/www/html/tw.rpi.edu/media/files" ;
-          $fullpath = $fulldir."/latest/".$oldName ;
-          $actualuri = $base."latest/".$oldName ;
+          $baseInstance = $this->getInstanceURI();
+          $actualuri = $baseInstance."/latest/".$oldName ;
           $defaultdocpage = $this->getDefaultDocPage() ;
           $page = $defaultdocpage."?uri=$actualuri" ;
         }
@@ -330,7 +329,8 @@ abstract class TWDocs {
     $params = array('http' => array('method' => 'POST',
             'content' => $msg));
     $ctx = stream_context_create($params);
-    $ans = @file_get_contents($this->getApiURL(),false,$ctx);
+    $apiURL = $this->getApiURL();
+    $ans = @file_get_contents($apiURL,false,$ctx);
     $answer = @json_decode($ans);
     return $answer;
   }
@@ -347,8 +347,10 @@ abstract class TWDocs {
   // Settings
   public abstract function shouldDebug();
   public abstract function enableDebug($val);
-  public abstract function getBaseURI();
-  public abstract function setBaseURI($val);
+  public abstract function getMediaURI();
+  public abstract function setMediaURI($val);
+  public abstract function getInstanceURI();
+  public abstract function setInstanceURI($val);
   public abstract function getServiceID();
   public abstract function setServiceID($val);
   public abstract function getApiKey();
@@ -356,8 +358,8 @@ abstract class TWDocs {
   public abstract function getDefaultDocPage();
   public abstract function setDefaultDocPage($val);
 
-  function getApiURL() {
-    return $this->getBaseURI()."api.php";
+  private function getApiURL() {
+    return $this->getMediaURI()."/api.php";
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! Here’s a template to help you format your PR.
 
Your title should look like: UXTALK-NUM Clear, brief title using imperative tense
For example: UXTALK-104 Refactor web consumer to handle API prefix removal
-->
 
### What does this PR do?
differentiates between the base uri where the media can be retrieved and the base uri of the instance data
 
### Motivation and context
 https://github.com/tetherless-world/twdocs-drupal8/issues/6
 
### Screenshots or videos, if appropriate
N/A
 
### How has this been tested?
Tested locally retrieving instance information for the media and links for the display of the media
 
### Checklist
 
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “[n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
 
* [x] Renders and functions properly in all supported browsers
* [x] Automated tests written and passing (n/a)
* [ ] Documentation created or updated, including (n/a)
* [x] There is a single commit with a [Good commit message](https://github.com/torvalds/subsurface-for-dirk/blob/master/README#L92) that starts with the Jira ticket
 
<!-- If any of the above need further details, you should include those here. -->
 
### How does this PR make you feel?
 
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
 
![I feel super](https://media.giphy.com/media/z0mMFvI7U27V6/giphy.gif)
